### PR TITLE
Fixed playlist typo & order option

### DIFF
--- a/yapi.py
+++ b/yapi.py
@@ -87,7 +87,7 @@ class YoutubeAPI:
         return channel
 
     def get_playlist_by_id(self, playlist_id):
-        api_url = manager.get_api('playlist')
+        api_url = manager.get_api('playlists')
         params = {
             'id': playlist_id,
             'part': 'id, snippet, status'
@@ -97,7 +97,7 @@ class YoutubeAPI:
         return playlist
 
     def get_playlist_by_channel_id(self, channel_id):
-        api_url = manager.get_api('playlist')
+        api_url = manager.get_api('playlists')
         params = {
             'channelId': channel_id,
             'part': 'id, snippet, status'

--- a/yapi.py
+++ b/yapi.py
@@ -59,7 +59,7 @@ class YoutubeAPI:
             'part': 'id, snippet',
             'maxResults': max_results
         }
-        if not order:
+        if order:
             params['order'] = order
 
 


### PR DESCRIPTION
Because of:
```
        self.APIs = {
            'videos': 'https://www.googleapis.com/youtube/v3/videos',
            'search': 'https://www.googleapis.com/youtube/v3/search',
            'channels': 'https://www.googleapis.com/youtube/v3/channels',
            'playlists': 'https://www.googleapis.com/youtube/v3/playlists',
            'playlistItems':
                'https://www.googleapis.com/youtube/v3/playlistItems'
        }
```